### PR TITLE
fix: address Codex review findings — numpy 3.13 wheels, asyncpg, and two dashboard crashes

### DIFF
--- a/dashboard/streamlit_app.py
+++ b/dashboard/streamlit_app.py
@@ -337,13 +337,14 @@ class FraudDetectionDashboard:
                     col1, col2 = st.columns(2)
                     
                     with col1:
-                        fraud_status = "🚨 FRAUD DETECTED" if result['is_fraud'] else "✅ LEGITIMATE"
+                        fraud_status = "🚨 FRAUD DETECTED" if result["is_fraud"] else "✅ LEGITIMATE"
                         color = "red" if result['is_fraud'] else "green"
                         st.markdown(f"<h3 style='color: {color};'>{fraud_status}</h3>", unsafe_allow_html=True)
                         
                         st.metric("Fraud Probability", f"{result['fraud_probability']:.3f}")
                         st.metric("Risk Score", f"{result['risk_score']:.1f}/100")
-                        st.metric("Confidence", result['confidence_level'].title())
+                        st.metric("Risk Level", result["risk_level"].title())
+                        st.metric("Decision", result["decision"].replace("_", " ").title())
                         st.metric("Processing Time", f"{result['processing_time_ms']:.2f}ms")
                     
                     with col2:
@@ -375,7 +376,7 @@ class FraudDetectionDashboard:
         # previously hardcoded to green and stayed green while the backend was
         # down - a status light that cannot turn red is not a status light.
         st.sidebar.subheader("📊 System Status")
-        health = self.api_client.fetch_health()
+        health = self.fetch_health()
 
         if health is None:
             st.sidebar.error("🔴 API: Unreachable")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,8 +51,7 @@ services:
       # Required in production; the app refuses to start without it.
       # Set it in a local .env file - never commit a real value.
       SECRET_KEY: ${SECRET_KEY:?set SECRET_KEY in .env before starting}
-      # asyncpg is needed for this URL: add it to requirements or use
-      # sqlite+aiosqlite for a dependency-free local run.
+      # asyncpg ships in requirements.txt, so this URL resolves at startup.
       DATABASE_URL: postgresql+asyncpg://fraud_user:${POSTGRES_PASSWORD:-fraud_password}@postgres:5432/fraud_detection
       REDIS_URL: redis://redis:6379/0
       ALLOWED_HOSTS: localhost,127.0.0.1,api

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,3 +12,14 @@ httpx==0.28.1          # required by fastapi.testclient
 # Linting and type checking
 ruff==0.16.0
 mypy==1.14.0
+
+# Dashboard extras. Required so tests/unit/test_dashboard.py actually runs in
+# CI rather than erroring on import - those tests exist because two dashboard
+# breakages shipped unnoticed and had to be caught in review. The tests skip
+# cleanly if these are absent, but then they guard nothing.
+#
+# streamlit must be >= 1.37: 1.32 caps numpy<2, which cannot co-exist with the
+# numpy 2.x required for Python 3.13 wheels.
+streamlit==1.50.0
+plotly==6.5.0
+requests==2.32.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,10 +18,14 @@ pydantic==2.11.3
 pydantic-settings==2.3.0
 python-multipart==0.0.32
 
-# Database. aiosqlite backs the default SQLite URL; greenlet is required by
-# SQLAlchemy's async engine. Add asyncpg for PostgreSQL.
+# Database. aiosqlite backs the default SQLite URL, asyncpg the PostgreSQL one
+# used by docker-compose; greenlet is required by SQLAlchemy's async engine.
+# Both drivers ship here because create_async_engine resolves the driver from
+# the URL scheme at startup - a missing one is a hard boot failure, not a
+# degraded mode.
 sqlalchemy==2.0.46
 aiosqlite==0.19.0
+asyncpg==0.30.0
 greenlet==3.3.0
 alembic==1.13.1
 
@@ -35,7 +39,13 @@ PyJWT==2.13.0
 
 # Numerics. Required by the fingerprinting and analytics helpers; joblib loads
 # trained model artefacts when MODEL_PATH contains any.
-numpy==1.26.4
+#
+# numpy 2.x is required for Python 3.13: 1.26.4 publishes no cp313 wheel, so
+# pip silently falls back to a source build - three minutes on a CI runner that
+# happens to have a compiler, and an outright failure on one that does not.
+# 2.3.x declares requires-python >=3.11, matching this project's floor, and
+# ships wheels for cp311 through cp314.
+numpy==2.3.5
 pandas==2.2.3
 joblib==1.5.2
 

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,9 @@ setup(
         # Kafka streaming pipeline.
         "streaming": ["kafka-python>=2.0.2"],
         # Streamlit monitoring dashboard.
-        "dashboard": ["streamlit>=1.32", "plotly>=5.20"],
+        # streamlit >= 1.37 caps numpy<3 rather than <2, so it co-exists
+        # with the numpy 2.x needed for Python 3.13.
+        "dashboard": ["streamlit>=1.37", "plotly>=5.20"],
         "dev": read_requirements("requirements-dev.txt"),
     },
     # The previous console_scripts pointed at five modules, three of which

--- a/tests/unit/test_dashboard.py
+++ b/tests/unit/test_dashboard.py
@@ -1,0 +1,221 @@
+"""
+Tests for the Streamlit dashboard.
+
+The dashboard had no tests, so two breakages shipped unnoticed and had to be
+caught in review: a call to `self.api_client.fetch_health()` where no
+`api_client` attribute exists, and a read of `result["confidence_level"]` after
+that field was removed from the API response.
+
+Streamlit's rendering cannot be exercised without a browser session, so instead
+of asserting on pixels these check the two things that actually broke - that
+the attributes the code calls on itself exist, and that the response fields it
+reads are really in the API schema. Both are static checks, so they catch the
+error without a running server.
+"""
+
+import ast
+import inspect
+import re
+from pathlib import Path
+
+import pytest
+
+from app.models.transaction_models import TransactionResponse
+
+# The dashboard is an optional extra (see setup.py). Skip rather than error
+# when it is not installed; requirements-dev.txt pulls it in so CI runs these.
+pytest.importorskip("streamlit", reason="dashboard extra not installed")
+pytest.importorskip("plotly", reason="dashboard extra not installed")
+
+SOURCE_PATH = Path(__file__).resolve().parents[2] / "dashboard" / "streamlit_app.py"
+SOURCE = SOURCE_PATH.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def dashboard_module():
+    import dashboard.streamlit_app as module
+
+    return module
+
+
+@pytest.fixture
+def dashboard(dashboard_module):
+    return dashboard_module.FraudDetectionDashboard()
+
+
+class TestSelfAttributesResolve:
+    """
+    Every `self.X` the class touches must exist on it.
+
+    `self.api_client.fetch_health()` raised AttributeError on every page load:
+    fetch_health is a method on this same class, and no api_client attribute
+    was ever assigned. Nothing failed until a human opened the page.
+    """
+
+    def test_every_self_attribute_exists(self, dashboard):
+        tree = ast.parse(SOURCE)
+        cls = next(
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.ClassDef) and node.name == "FraudDetectionDashboard"
+        )
+
+        referenced = {
+            node.attr
+            for node in ast.walk(cls)
+            if isinstance(node, ast.Attribute)
+            and isinstance(node.value, ast.Name)
+            and node.value.id == "self"
+        }
+
+        missing = sorted(name for name in referenced if not hasattr(dashboard, name))
+
+        assert not missing, f"FraudDetectionDashboard has no attribute: {missing}"
+
+
+class TestResponseContract:
+    """
+    The dashboard may only read fields the API actually returns.
+
+    `result["confidence_level"]` survived that field's removal from
+    TransactionResponse and would have raised KeyError on the first successful
+    test transaction.
+    """
+
+    def test_every_result_field_exists_in_the_response_model(self):
+        read_fields = set(re.findall(r"""result\[["']([a-z_]+)["']\]""", SOURCE))
+
+        assert read_fields, "expected the tester to read some response fields"
+
+        unknown = sorted(read_fields - set(TransactionResponse.model_fields))
+
+        assert not unknown, f"dashboard reads fields absent from TransactionResponse: {unknown}"
+
+
+class TestFailureIsVisible:
+    """A dead backend must look dead, not busy."""
+
+    def test_analytics_returns_none_when_the_api_is_unreachable(self, dashboard, monkeypatch):
+        import requests
+
+        def refuse(*args, **kwargs):
+            raise requests.ConnectionError("connection refused")
+
+        monkeypatch.setattr(dashboard.session, "get", refuse)
+
+        assert dashboard.fetch_analytics_data() is None
+
+    def test_health_returns_none_when_the_api_is_unreachable(self, dashboard, monkeypatch):
+        import requests
+
+        def refuse(*args, **kwargs):
+            raise requests.ConnectionError("connection refused")
+
+        monkeypatch.setattr(dashboard.session, "get", refuse)
+
+        assert dashboard.fetch_health() is None
+
+    def test_no_fabricated_fallback_data_remains(self, dashboard_module):
+        """
+        The removed mock returned 15847 transactions and 99.87% accuracy on any
+        API failure, so an operator watching a dead system saw a healthy one.
+
+        Checked against literals in the parsed tree rather than raw text, so a
+        number quoted in a comment or docstring explaining the old behaviour
+        does not count as the behaviour returning.
+        """
+        literals = {
+            node.value
+            for node in ast.walk(ast.parse(SOURCE))
+            if isinstance(node, ast.Constant) and isinstance(node.value, (int, float))
+        }
+
+        assert not hasattr(dashboard_module.FraudDetectionDashboard, "_get_mock_data")
+        assert 15847 not in literals
+        assert 99.87 not in literals
+
+    def test_api_status_is_derived_from_a_health_call(self):
+        """
+        The indicators were hardcoded to green and stayed green while the API
+        was unreachable. A status light that cannot turn red is not one.
+
+        The literal "API: Online" still appears, but only inside the branch
+        taken when a health response came back, so this asserts on the call
+        rather than on the string.
+        """
+        tree = ast.parse(SOURCE)
+        render_sidebar = next(
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.FunctionDef) and node.name == "render_sidebar"
+        )
+
+        called = {
+            node.func.attr
+            for node in ast.walk(render_sidebar)
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
+        }
+
+        assert "fetch_health" in called
+
+    def test_unreachable_api_is_reported_as_unreachable(self, dashboard, monkeypatch):
+        """The red path must exist and be reachable, not just be written down."""
+        monkeypatch.setattr(dashboard, "fetch_health", lambda: None)
+
+        rendered = []
+        import streamlit as st
+
+        monkeypatch.setattr(st.sidebar, "error", lambda msg, *a, **k: rendered.append(msg))
+        monkeypatch.setattr(st.sidebar, "success", lambda msg, *a, **k: rendered.append(msg))
+        monkeypatch.setattr(st.sidebar, "warning", lambda msg, *a, **k: rendered.append(msg))
+        monkeypatch.setattr(st.sidebar, "subheader", lambda *a, **k: None)
+        monkeypatch.setattr(st.sidebar, "write", lambda *a, **k: None)
+        monkeypatch.setattr(st.sidebar, "title", lambda *a, **k: None)
+        monkeypatch.setattr(st.sidebar, "selectbox", lambda *a, **k: 7)
+
+        dashboard.render_sidebar()
+
+        assert any("Unreachable" in str(message) for message in rendered)
+        assert not any("API: Online" in str(message) for message in rendered)
+
+
+class TestAuthentication:
+    def test_bearer_token_is_sent_when_configured(self, dashboard_module, monkeypatch):
+        monkeypatch.setenv("API_TOKEN", "a-test-token")
+
+        dashboard = dashboard_module.FraudDetectionDashboard()
+
+        assert dashboard.session.headers["Authorization"] == "Bearer a-test-token"
+
+    def test_no_authorization_header_without_a_token(self, dashboard_module, monkeypatch):
+        monkeypatch.delenv("API_TOKEN", raising=False)
+
+        dashboard = dashboard_module.FraudDetectionDashboard()
+
+        assert "Authorization" not in dashboard.session.headers
+
+
+class TestDemoDashboardIsLabelled:
+    """
+    dashboard/app.py serves random numbers. It must never be mistakable for
+    real monitoring.
+    """
+
+    def test_demo_app_declares_itself(self):
+        import dashboard.app as demo
+
+        assert "DEMO" in demo.app.title
+
+    def test_demo_page_carries_a_banner(self):
+        template = (SOURCE_PATH.parent / "templates" / "index.html").read_text(encoding="utf-8")
+
+        assert "DEMO" in template
+
+    def test_demo_module_says_the_data_is_synthetic(self):
+        import dashboard.app as demo
+
+        assert "synthetic" in inspect.getdoc(demo).lower()
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
Follow-up to #24, which merged before these landed. All four review findings were valid; two were breakages I introduced there and reported as fixed without ever running the file.

## 1. numpy 1.26.4 has no cp313 wheel (P1)

The review said `pip install` fails on Python 3.13. It doesn't fail — but only because pip falls back to a source build, which the CI log from #24 shows plainly:

```
Using cached numpy-1.26.4.tar.gz (15.8 MB)
Created wheel for numpy: numpy-1.26.4-cp313-cp313-linux_x86_64.whl
```

08:28:07 → 08:31:01. Three minutes compiling, which is why the 3.13 job took **3m24s** against ~29s for 3.11 and 3.12. And the underlying claim is right:

```
$ pip download --only-binary=:all: numpy==1.26.4
ERROR: Could not find a version that satisfies the requirement numpy==1.26.4
       (from versions: 2.1.0, 2.1.1, ... 2.5.1)
```

No cp313 wheel exists below 2.1.0. It worked only because the GitHub runner has a compiler; any machine without one fails outright. My clean-venv check missed it because I confirmed the install *succeeded* without looking at *how*.

Moved to `numpy==2.3.5` — `requires-python >=3.11` (this project's floor) with wheels for cp311–cp314. The only numpy usage here is two `np.array()` calls, so none of the 2.x removals (`np.float_`, `np.NaN`, copy semantics) apply.

## 2. asyncpg missing (P1)

`docker-compose.yml` sets a `postgresql+asyncpg://` URL and `create_async_engine` resolves the driver from the scheme at startup, so `docker compose up` died on a missing driver. I had written a comment *describing* the problem instead of fixing it. Added `asyncpg==0.30.0`; both drivers ship because a missing one is a hard boot failure, not a degraded mode.

## 3 & 4. Two dashboard crashes (P2, both mine)

- `render_sidebar` called `self.api_client.fetch_health()` — `fetch_health` is a method on the same class and no `api_client` attribute is ever assigned. **AttributeError on every page load.** Confirmed: `hasattr(dash, 'api_client')` → `False`.
- It read `result["confidence_level"]` after I removed that field from `TransactionResponse`. **KeyError on every successful test transaction.**

**Root cause: the dashboard had zero tests**, so nothing failed until a human opened the page. Adds `tests/unit/test_dashboard.py` checking the two properties that actually broke:

- every `self.X` the class touches resolves (AST walk + `hasattr`)
- every response field it reads exists in `TransactionResponse.model_fields`

Both were confirmed to **fail against the original bugs** before being committed — I reintroduced each and watched the right test go red:

```
bug 1 restored → FAILED TestSelfAttributesResolve::test_every_self_attribute_exists
                 FAILED TestFailureIsVisible::test_unreachable_api_is_reported_as_unreachable
bug 2 restored → FAILED TestResponseContract::test_every_result_field_exists_in_the_response_model
```

## A fifth issue those tests then exposed

Running them in a clean environment failed to install at all:

```
streamlit 1.32.0 depends on numpy<2
ERROR: ResolutionImpossible
```

My local environment had streamlit 1.32 and numpy 2.3.5 coexisting only because I upgraded numpy in place — the dependency graph was invalid and nothing surfaced it until a clean install. Moved to `streamlit==1.50.0`, which caps `numpy<3`.

The dashboard extras now live in `requirements-dev.txt` so CI actually executes these tests, with `pytest.importorskip` so a minimal install skips cleanly rather than erroring.

## Verification

Fresh venv from `requirements.txt` + `requirements-dev.txt`:

```
142 passed              (bare `pytest`, as CI invokes it)
numpy-2.3.5-cp313-cp313-win_amd64.whl     ← wheel, no source build
asyncpg-0.30.0-cp313-cp313-win_amd64.whl
pip-audit --strict     No known vulnerabilities found
python -m build + twine check   both PASSED
ruff check / format    clean
```

Also confirmed `create_async_engine('postgresql+asyncpg://...')` resolves `driver: asyncpg` — the compose URL now works.

Thanks to the reviewer; three of these would have reached a user.
