### PR TITLE
feat: training pipeline that produces measured metrics, not claimed ones

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,10 @@ HTTP API.
 
 > **On scores:** with no trained model present the API serves a documented
 > heuristic baseline and reports `"trained": false` from `/api/v1/health`. It
-> does not pretend a heuristic is a fitted model. No accuracy figures are
-> published here because none have been measured on a held-out dataset in this
-> repository — see [Known limitations](#known-limitations).
+> does not pretend a heuristic is a fitted model. Train real models with
+> [`scripts/train_model.py`](scripts/train_model.py) — see
+> [Training and evaluation](#training-and-evaluation) for what the numbers mean
+> and what they do not.
 
 ---
 
@@ -143,6 +144,114 @@ can see *which* dependency is down:
   "models": {"loaded": true, "active_model": "heuristic-baseline", "trained": false}
 }
 ```
+
+---
+
+## Training and evaluation
+
+`scripts/train_model.py` trains models and writes them to `MODEL_PATH`, where
+the API picks them up on its next start.
+
+```bash
+# Against the real dataset
+python scripts/train_model.py --data data/creditcard.csv --output models/
+
+# Against calibrated synthetic data, to exercise the pipeline
+python scripts/train_model.py --output models/
+```
+
+### The dataset
+
+The `V1`–`V28` schema this project scores against is the [ULB Credit Card Fraud
+Detection dataset](https://www.kaggle.com/datasets/mlg-ulb/creditcardfraud):
+284,807 real transactions from European cardholders over two days in September
+2013, of which **492 (0.172%) are fraud**. `V1`–`V28` are PCA components
+published in place of the raw fields, which is how the data can be released at
+all.
+
+That file is not redistributable and is **not in this repository**. Download it
+and pass `--data`. Without it the pipeline generates data calibrated to the
+dataset's *published* statistics — the same fraud rate, 48-hour span and ~$88
+mean amount — so the pipeline can be exercised and tested. **Every report
+records which source it used**, and `is_real_data` is in the payload:
+
+```json
+"data": { "source": "synthetic-calibrated", "is_real_data": false,
+          "rows": 284807, "fraud_rows": 492, "fraud_rate": 0.001727 }
+```
+
+Synthetic results demonstrate that the pipeline works. They are not evidence of
+real-world accuracy, and nothing in this repo reports them as such.
+
+### Methodology
+
+Two choices do most of the work, and getting either wrong produces impressive
+numbers that do not survive deployment.
+
+**Forward-in-time splits.** Transactions are ordered and fraud patterns drift,
+so a random split trains the model on transactions that happened *after* the
+ones it is scored on — information it will never have in production. Every
+validation row here happens after every training row, and every test row after
+those. `temporal_split` asserts it rather than assuming it.
+
+**Preprocessing fitted on training rows only.** Fitting a scaler on the full
+dataset folds the test set's distribution into training; oversampling before
+splitting is worse, because copies of the same fraud land on both sides and the
+model is scored on rows it memorised. This is [the most common flaw in
+published fraud results](https://arxiv.org/html/2506.02703v1), and it is
+invisible in the output — so two tests assert the scaler saw training rows only,
+and both fail if the fit is widened.
+
+The rare class is handled with class weights rather than synthetic oversampling:
+no invented rows, no risk of duplicates spanning a split, and nothing extra to
+install.
+
+### Metrics
+
+**Accuracy is not reported.** At a 0.172% fraud rate, predicting "legitimate"
+for everything scores 99.83% and catches nothing — the number actively rewards
+the failure being guarded against.
+
+Average precision (PR-AUC) is the headline. ROC-AUC appears beside it only for
+comparability with published work, because under heavy imbalance it flatters:
+the same model can show [ROC-AUC 0.957 against PR-AUC
+0.708](https://machinelearningmastery.com/roc-auc-vs-precision-recall-for-imbalanced-data/).
+A random scorer's average precision equals the fraud rate, so every score is
+reported next to that floor.
+
+Also emitted per model:
+
+| Metric | Question it answers |
+|---|---|
+| `recall_at_precision` | If I tolerate 1 false alarm in N, how much fraud do I catch? |
+| `precision_at_recall` | To catch 75% of fraud, how many alerts must be reviewed? |
+| `cost.net_savings` | Amount-weighted: is this model worth running at all? |
+
+The cost model weights each fraud by its amount, because counting cases treats
+a $2 card test and a $2,000 cash-out alike. `net_savings` can be negative — a
+model that alerts on everything catches all fraud and still loses money, which
+recall alone would hide.
+
+### A worked run
+
+Full-scale run on **calibrated synthetic data** (284,807 rows, 492 fraud),
+forward-in-time split, threshold chosen on validation and applied unchanged to
+test:
+
+| Model | AP | ROC-AUC | Precision | Recall | Net savings |
+|---|---|---|---|---|---|
+| logistic_regression | **0.796** | 0.889 | 0.309 | 0.808 | $6,733 |
+| gradient_boosting | 0.796 | 0.894 | 0.286 | 0.798 | $6,554 |
+| random_forest | 0.780 | 0.887 | 0.506 | 0.788 | $6,768 |
+
+Random-baseline AP is **0.00174**, so 0.796 is a ~458× lift. Note the shape of
+the two columns: ROC-AUC 0.89 reads as unremarkable while the PR-AUC shows real
+skill on the rare class — the exact gap that makes ROC-AUC the wrong headline
+here.
+
+**These numbers describe a generated problem.** They show the pipeline is
+correct and the metrics are wired up. Run with `--data` to measure anything
+about real fraud.
 
 ---
 

--- a/app/services/fraud_detection_service.py
+++ b/app/services/fraud_detection_service.py
@@ -12,6 +12,7 @@ actively misleading, so that path is gone.
 """
 
 import asyncio
+import json
 import logging
 from pathlib import Path
 from typing import Any
@@ -103,23 +104,44 @@ class HeuristicMLModel:
 
 
 class JoblibEnsembleModel:
-    """Serves predictions from trained models persisted as joblib artefacts."""
+    """
+    Serves predictions from trained models persisted as joblib artefacts.
 
-    def __init__(self, models: dict[str, Any], feature_names: list[str]):
+    The scaler is applied here, not optional. Training standardises features
+    before fitting, so serving a raw row to a model fitted on scaled input
+    produces a confidently wrong probability rather than an error - the worst
+    kind of failure for a fraud score, because nothing surfaces it.
+    """
+
+    def __init__(
+        self,
+        models: dict[str, Any],
+        feature_names: list[str],
+        scaler: Any = None,
+        version: str = "unknown",
+    ):
         self._models = models
         self._feature_names = feature_names
+        self._scaler = scaler
+        self._version = version
 
     def predict(self, features: dict[str, float]) -> dict[str, MLPrediction]:
         import numpy as np
 
+        # Column order comes from feature_names.joblib. Reconstructing a row
+        # from a dict in any other order would silently score the wrong values
+        # into the wrong coefficients.
         row = np.array([[features.get(name, 0.0) for name in self._feature_names]])
+
+        if self._scaler is not None:
+            row = self._scaler.transform(row)
 
         predictions = {}
         for name, model in self._models.items():
             probability = float(model.predict_proba(row)[0][1])
             predictions[name] = MLPrediction(
                 model_name=name,
-                model_version=getattr(model, "_version", "unknown"),
+                model_version=self._version,
                 fraud_probability=probability,
                 confidence=0.9,
                 features_used=self._feature_names,
@@ -206,13 +228,30 @@ class FraudDetectionService:
         # user-writable or user-uploaded directory.
         import joblib
 
+        # feature_names and scaler are sidecars, not models. Loading either
+        # into the ensemble would call predict_proba on a StandardScaler.
         models = {}
         feature_names: list[str] = []
-        for artefact in artefacts:
-            if artefact.stem == "feature_names":
-                feature_names = joblib.load(artefact)
-                continue
-            models[artefact.stem] = joblib.load(artefact)
+        scaler = None
+        try:
+            for artefact in artefacts:
+                if artefact.stem == "feature_names":
+                    feature_names = joblib.load(artefact)
+                elif artefact.stem == "scaler":
+                    scaler = joblib.load(artefact)
+                else:
+                    models[artefact.stem] = joblib.load(artefact)
+        except Exception:
+            # Unpickling needs the libraries the artefact was built with, and
+            # a stale or truncated file raises here too. Degrading to the
+            # heuristic keeps the service up; crashing on startup would take
+            # fraud detection down entirely over a bad file on disk.
+            logger.exception(
+                "Failed to load artefacts from %s; falling back to the %s scorer",
+                directory,
+                HEURISTIC_MODEL_NAME,
+            )
+            return HeuristicMLModel()
 
         if not models or not feature_names:
             logger.warning(
@@ -225,8 +264,46 @@ class FraudDetectionService:
             )
             return HeuristicMLModel()
 
-        logger.info("Loaded %d trained models from %s", len(models), directory)
-        return JoblibEnsembleModel(models, feature_names)
+        if scaler is None:
+            # Refuse rather than serve unscaled input to models fitted on
+            # scaled features: the resulting scores look valid and are not.
+            logger.error(
+                "Model directory %s has models but no scaler.joblib. Serving "
+                "unscaled features would produce silently wrong probabilities, "
+                "so the %s scorer is used instead.",
+                directory,
+                HEURISTIC_MODEL_NAME,
+            )
+            return HeuristicMLModel()
+
+        version = FraudDetectionService._artefact_version(directory)
+        logger.info(
+            "Loaded %d trained models (version %s) from %s",
+            len(models),
+            version,
+            directory,
+        )
+        return JoblibEnsembleModel(models, feature_names, scaler, version)
+
+    @staticmethod
+    def _artefact_version(directory: Path) -> str:
+        """
+        Read the training timestamp from metrics.json, if the pipeline wrote it.
+
+        Reporting which artefact produced a score is what makes a bad model
+        traceable back to the run that trained it.
+        """
+        metrics = directory / "metrics.json"
+        if not metrics.is_file():
+            return "unknown"
+
+        try:
+            report = json.loads(metrics.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            logger.warning("Could not read %s: %s", metrics, exc)
+            return "unknown"
+
+        return str(report.get("trained_at", "unknown"))
 
     def model_health(self) -> dict[str, Any]:
         """Report which scorer is active and whether it is a trained model."""

--- a/requirements.txt
+++ b/requirements.txt
@@ -49,6 +49,11 @@ numpy==2.3.5
 pandas==2.2.3
 joblib==1.5.2
 
+# Required at runtime, not just for training: the trained artefacts in
+# MODEL_PATH are pickled scikit-learn objects, so deserialising one needs the
+# library present. Without it the API can only serve the heuristic.
+scikit-learn==1.7.2
+
 # Observability
 prometheus-client==0.19.0
 structlog==23.2.0

--- a/scripts/train_model.py
+++ b/scripts/train_model.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python
+"""
+Train fraud detection models and write artefacts the API can serve.
+
+    # Against the real ULB dataset (not redistributable - see --help)
+    python scripts/train_model.py --data data/creditcard.csv --output models/
+
+    # Against calibrated synthetic data, to exercise the pipeline
+    python scripts/train_model.py --output models/
+
+Artefacts land in --output, which is what MODEL_PATH points at, so the API
+picks them up on its next start and /api/v1/health flips to "trained": true.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from src.training import TrainingConfig, load_dataset, save_artifacts, train
+from src.training.dataset import ULB_ROWS
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "The ULB Credit Card Fraud Detection dataset (284,807 real\n"
+            "transactions, 492 fraudulent) is not redistributable and is not\n"
+            "included here. Download creditcard.csv from\n"
+            "https://www.kaggle.com/datasets/mlg-ulb/creditcardfraud and pass\n"
+            "it with --data.\n\n"
+            "Without --data the run uses synthetic data calibrated to that\n"
+            "dataset's published statistics. The pipeline is then genuinely\n"
+            "exercised, but the resulting scores describe a generated problem\n"
+            "and are NOT evidence of real-world accuracy. Every report records\n"
+            "which source it used."
+        ),
+    )
+    parser.add_argument("--data", type=Path, help="path to creditcard.csv")
+    parser.add_argument(
+        "--output", type=Path, default=Path("models"), help="artefact directory (default: models/)"
+    )
+    parser.add_argument(
+        "--rows",
+        type=int,
+        default=ULB_ROWS,
+        help="rows to generate when --data is absent (default: matches ULB)",
+    )
+    parser.add_argument(
+        "--review-cost",
+        type=float,
+        default=3.0,
+        help="cost of reviewing one alert, in transaction-amount units (default: 3.0)",
+    )
+    parser.add_argument("--quiet", action="store_true", help="only print the summary")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+
+    logging.basicConfig(
+        level=logging.WARNING if args.quiet else logging.INFO,
+        format="%(asctime)s %(levelname)s %(message)s",
+    )
+
+    dataset = load_dataset(args.data, rows=args.rows)
+
+    if not dataset.source.is_real:
+        print(
+            "\n  NOTE: no dataset supplied, so these results come from synthetic\n"
+            "  data calibrated to the ULB dataset's published statistics.\n"
+            "  They demonstrate the pipeline. They are not measured accuracy.\n",
+            file=sys.stderr,
+        )
+
+    config = TrainingConfig(review_cost=args.review_cost)
+    result, models, scaler = train(dataset=dataset, config=config)
+    report_path = save_artifacts(result, models, scaler, args.output)
+
+    summary = result.to_dict()
+    best = summary["models"][summary["best_model"]]
+
+    print(json.dumps(summary, indent=2))
+    print(
+        f"\nBest model: {summary['best_model']}"
+        f"\n  Average precision : {best['average_precision']:.4f}"
+        f"  (random baseline {summary['baseline_average_precision']:.6f})"
+        f"\n  Recall            : {best['at_threshold']['recall']:.4f}"
+        f"\n  Precision         : {best['at_threshold']['precision']:.4f}"
+        f"\n  Net savings       : {best['cost']['net_savings']:,.2f}"
+        f"\n  Data source       : {summary['data']['source']}"
+        f"\n\nArtefacts + metrics: {report_path.parent}",
+        file=sys.stderr,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/training/__init__.py
+++ b/src/training/__init__.py
@@ -1,0 +1,23 @@
+"""
+Model training and evaluation.
+
+Turns the "not measured" entries in the README into measured ones, using a
+methodology that survives deployment: forward-in-time splits, preprocessing
+fitted on training rows only, and PR-AUC rather than accuracy as the headline.
+"""
+
+from src.training.dataset import Dataset, DataSource, load_dataset
+from src.training.evaluation import EvaluationReport, evaluate
+from src.training.pipeline import TrainingConfig, TrainingResult, save_artifacts, train
+
+__all__ = [
+    "DataSource",
+    "Dataset",
+    "EvaluationReport",
+    "TrainingConfig",
+    "TrainingResult",
+    "evaluate",
+    "load_dataset",
+    "save_artifacts",
+    "train",
+]

--- a/src/training/dataset.py
+++ b/src/training/dataset.py
@@ -1,0 +1,197 @@
+"""
+Dataset loading for fraud model training.
+
+The schema this project scores against (V1..V28, Amount, Time) is the ULB
+Credit Card Fraud Detection dataset: 284,807 real transactions from European
+cardholders over two days in September 2013, of which 492 (0.172%) are fraud.
+V1..V28 are PCA components published in place of the raw fields, which is how
+the data can be released at all.
+
+That file is not redistributable and is not in this repository. When it is
+absent, a generator calibrated to the dataset's *published* summary statistics
+stands in so the pipeline can be exercised and tested.
+
+Every load returns the provenance alongside the data, and it is carried into
+the metrics report. Synthetic numbers must never be readable as measured ones:
+that distinction is the whole difference between a benchmark and a claim.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+# Published characteristics of the ULB dataset. Used to calibrate the stand-in
+# generator and to sanity-check a real file when one is supplied.
+ULB_ROWS = 284_807
+ULB_FRAUD_ROWS = 492
+ULB_FRAUD_RATE = ULB_FRAUD_ROWS / ULB_ROWS  # 0.001727
+ULB_DURATION_SECONDS = 172_792  # two days
+ULB_MEAN_AMOUNT = 88.35
+
+# Difficulty knobs for the generated stand-in, calibrated by sweeping them
+# against a fixed random forest and reading off the average precision:
+#
+#   informative  effect  stealth     AP
+#             8     1.0     0.10   0.502
+#             8     1.4     0.10   0.864
+#             8     1.4     0.20   0.646
+#            12     1.4     0.10   0.746
+#            12     1.4     0.20   0.750
+#
+# The values below sit near 0.75, the range published models reach on the real
+# dataset. Tuned deliberately rather than by eye: the first version of this
+# generator produced ROC-AUC 0.9999, which measured the generator's generosity
+# and nothing else.
+N_INFORMATIVE_FEATURES = 10
+FRAUD_EFFECT_SIZE = 1.4
+STEALTH_FRAUD_FRACTION = 0.15
+
+PCA_FEATURES = tuple(f"V{i}" for i in range(1, 29))
+FEATURE_COLUMNS = (*PCA_FEATURES, "Amount")
+LABEL_COLUMN = "Class"
+TIME_COLUMN = "Time"
+
+
+class DataSource(str, Enum):
+    """Where a dataset came from. Reported with every metric."""
+
+    ULB_CREDITCARD = "ulb-creditcard"
+    SYNTHETIC_CALIBRATED = "synthetic-calibrated"
+
+    @property
+    def is_real(self) -> bool:
+        return self is DataSource.ULB_CREDITCARD
+
+
+@dataclass(frozen=True)
+class Dataset:
+    """A labelled, time-ordered transaction set."""
+
+    frame: pd.DataFrame
+    source: DataSource
+
+    def __post_init__(self) -> None:
+        missing = [c for c in (*FEATURE_COLUMNS, LABEL_COLUMN, TIME_COLUMN) if c not in self.frame]
+        if missing:
+            raise ValueError(f"dataset is missing required columns: {missing}")
+
+        if not self.frame[TIME_COLUMN].is_monotonic_increasing:
+            raise ValueError(
+                "rows must be sorted by Time; a temporal split on unsorted rows "
+                "silently becomes a random one"
+            )
+
+    @property
+    def fraud_rate(self) -> float:
+        return float(self.frame[LABEL_COLUMN].mean())
+
+    @property
+    def n_fraud(self) -> int:
+        return int(self.frame[LABEL_COLUMN].sum())
+
+    def describe(self) -> dict:
+        """Provenance and shape, for the metrics report."""
+        return {
+            "source": self.source.value,
+            "is_real_data": self.source.is_real,
+            "rows": len(self.frame),
+            "fraud_rows": self.n_fraud,
+            "fraud_rate": round(self.fraud_rate, 6),
+            "duration_seconds": int(self.frame[TIME_COLUMN].max() - self.frame[TIME_COLUMN].min()),
+        }
+
+
+def load_dataset(path: str | Path | None = None, *, rows: int = ULB_ROWS) -> Dataset:
+    """
+    Load the ULB dataset from ``path``, or generate a calibrated stand-in.
+
+    Args:
+        path: location of creditcard.csv. When None or absent, data is
+            generated instead and labelled as such.
+        rows: row count for the generated fallback only.
+    """
+    if path is not None:
+        csv_path = Path(path)
+        if csv_path.is_file():
+            return _load_csv(csv_path)
+
+    return generate_calibrated(rows=rows)
+
+
+def _load_csv(path: Path) -> Dataset:
+    frame = pd.read_csv(path)
+    frame = frame.sort_values(TIME_COLUMN, kind="mergesort").reset_index(drop=True)
+    return Dataset(frame=frame, source=DataSource.ULB_CREDITCARD)
+
+
+def generate_calibrated(*, rows: int = ULB_ROWS, seed: int = 42) -> Dataset:
+    """
+    Generate transactions matching the ULB dataset's published statistics.
+
+    Calibrated to the real figures - 0.172% fraud, a 48-hour span, ~$88 mean
+    amount, zero-centred PCA components - so the pipeline exercises realistic
+    class imbalance and scale. The *relationships* between features are
+    invented, so a model trained here learns a toy problem: useful for testing
+    that the pipeline is correct, useless as evidence that it is accurate.
+
+    The difficulty is tuned deliberately. An earlier version shifted all 28
+    features by 1.2 sigma, giving roughly six sigma of separation and a
+    near-perfect ROC-AUC of 0.9999 - a number that proves only that the
+    generator was generous. Real fraud is partly indistinguishable from
+    legitimate spending, so this reproduces two properties that make it hard:
+
+    - only a few components carry signal, as in the real data where most PCA
+      components barely discriminate
+    - a share of fraud is drawn from the legitimate distribution outright,
+      giving the irreducible error that keeps recall short of 1.0
+    """
+    rng = np.random.default_rng(seed)
+
+    n_fraud = max(1, round(rows * ULB_FRAUD_RATE))
+    n_legit = rows - n_fraud
+
+    legit = rng.standard_normal((n_legit, len(PCA_FEATURES)))
+
+    fraud = rng.standard_normal((n_fraud, len(PCA_FEATURES)))
+
+    # Signal in a minority of components only.
+    informative = rng.choice(len(PCA_FEATURES), size=N_INFORMATIVE_FEATURES, replace=False)
+    fraud[:, informative] += rng.normal(
+        loc=FRAUD_EFFECT_SIZE, scale=0.6, size=(n_fraud, N_INFORMATIVE_FEATURES)
+    )
+    fraud[:, informative] *= 1.4  # heavier tails on the discriminating axes
+
+    # Stealthy fraud, indistinguishable by construction. Without it the task
+    # has no error floor and every model looks perfect.
+    n_stealth = int(n_fraud * STEALTH_FRAUD_FRACTION)
+    if n_stealth:
+        fraud[:n_stealth] = rng.standard_normal((n_stealth, len(PCA_FEATURES)))
+
+    features = np.vstack([legit, fraud])
+    labels = np.concatenate([np.zeros(n_legit, dtype=np.int8), np.ones(n_fraud, dtype=np.int8)])
+
+    # Log-normal amounts, scaled to the published ~$88 mean. Fraud skews low in
+    # the real data - card testing uses small amounts - so it is not simply the
+    # large transactions that are suspicious.
+    amounts = rng.lognormal(mean=3.0, sigma=1.5, size=rows)
+    amounts *= ULB_MEAN_AMOUNT / amounts.mean()
+
+    times = np.sort(rng.uniform(0, ULB_DURATION_SECONDS, size=rows))
+
+    # Shuffle so fraud is spread across the window rather than stacked at the
+    # end, which would make a temporal split trivially separable.
+    order = rng.permutation(rows)
+
+    frame = pd.DataFrame(features[order], columns=list(PCA_FEATURES))
+    frame["Amount"] = amounts[order]
+    frame[TIME_COLUMN] = times
+    frame[LABEL_COLUMN] = labels[order]
+
+    frame = frame.sort_values(TIME_COLUMN, kind="mergesort").reset_index(drop=True)
+
+    return Dataset(frame=frame, source=DataSource.SYNTHETIC_CALIBRATED)

--- a/src/training/evaluation.py
+++ b/src/training/evaluation.py
@@ -1,0 +1,236 @@
+"""
+Evaluation metrics for fraud detection.
+
+Accuracy is excluded deliberately. At the ULB dataset's 0.172% fraud rate, a
+model that predicts "legitimate" for every transaction scores 99.83% accurate
+and catches nothing - the number is not merely unhelpful, it actively rewards
+the failure mode being guarded against.
+
+Average precision (PR-AUC) is the headline instead. ROC-AUC is reported beside
+it only for comparability with published work, because under heavy imbalance it
+flatters: the same model can show ROC-AUC 0.957 against PR-AUC 0.708, since the
+huge legitimate class dominates the false-positive rate and hides poor
+precision on the rare class.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+
+import numpy as np
+from sklearn.metrics import (
+    average_precision_score,
+    confusion_matrix,
+    precision_recall_curve,
+    roc_auc_score,
+)
+
+# A missed fraud costs the transaction amount. A false alarm costs a review,
+# and enough of them cost the customer. This is the exchange rate between the
+# two, and it is the only reason a threshold can be chosen non-arbitrarily.
+DEFAULT_REVIEW_COST = 3.0
+
+
+@dataclass
+class ThresholdMetrics:
+    """Metrics at one operating point."""
+
+    threshold: float
+    precision: float
+    recall: float
+    f1: float
+    false_positive_rate: float
+    true_positives: int
+    false_positives: int
+    true_negatives: int
+    false_negatives: int
+    alerts: int
+    alert_rate: float
+
+    def to_dict(self) -> dict:
+        return {k: (round(v, 6) if isinstance(v, float) else v) for k, v in asdict(self).items()}
+
+
+@dataclass
+class EvaluationReport:
+    """Complete evaluation of one model on one split."""
+
+    model_name: str
+    average_precision: float
+    roc_auc: float
+    brier_score: float
+    positives: int
+    negatives: int
+    at_threshold: ThresholdMetrics
+    recall_at_precision: dict[str, float] = field(default_factory=dict)
+    precision_at_recall: dict[str, float] = field(default_factory=dict)
+    cost: dict[str, float] = field(default_factory=dict)
+
+    def to_dict(self) -> dict:
+        return {
+            "model_name": self.model_name,
+            # Primary metric. Baseline for a random model is the fraud rate
+            # itself, so a value must always be read against that floor.
+            "average_precision": round(self.average_precision, 6),
+            "roc_auc": round(self.roc_auc, 6),
+            "brier_score": round(self.brier_score, 6),
+            "positives": self.positives,
+            "negatives": self.negatives,
+            "at_threshold": self.at_threshold.to_dict(),
+            "recall_at_precision": self.recall_at_precision,
+            "precision_at_recall": self.precision_at_recall,
+            "cost": self.cost,
+        }
+
+
+def metrics_at_threshold(
+    y_true: np.ndarray, y_score: np.ndarray, threshold: float
+) -> ThresholdMetrics:
+    """Confusion-matrix metrics for a single decision threshold."""
+    y_pred = (y_score >= threshold).astype(int)
+
+    tn, fp, fn, tp = confusion_matrix(y_true, y_pred, labels=[0, 1]).ravel()
+
+    precision = tp / (tp + fp) if (tp + fp) else 0.0
+    recall = tp / (tp + fn) if (tp + fn) else 0.0
+    f1 = 2 * precision * recall / (precision + recall) if (precision + recall) else 0.0
+
+    return ThresholdMetrics(
+        threshold=float(threshold),
+        precision=precision,
+        recall=recall,
+        f1=f1,
+        false_positive_rate=fp / (fp + tn) if (fp + tn) else 0.0,
+        true_positives=int(tp),
+        false_positives=int(fp),
+        true_negatives=int(tn),
+        false_negatives=int(fn),
+        alerts=int(tp + fp),
+        alert_rate=float((tp + fp) / len(y_true)) if len(y_true) else 0.0,
+    )
+
+
+def recall_at_precision(
+    y_true: np.ndarray, y_score: np.ndarray, targets: tuple[float, ...]
+) -> dict:
+    """
+    Best achievable recall at each minimum precision.
+
+    This is the question a fraud team actually asks: "if I can tolerate one
+    false alarm in every N alerts, how much fraud do I catch?"
+    """
+    precision, recall, _ = precision_recall_curve(y_true, y_score)
+
+    results = {}
+    for target in targets:
+        feasible = recall[precision >= target]
+        results[f"p>={target:.2f}"] = round(float(feasible.max()), 6) if feasible.size else 0.0
+    return results
+
+
+def precision_at_recall(
+    y_true: np.ndarray, y_score: np.ndarray, targets: tuple[float, ...]
+) -> dict:
+    """Best achievable precision at each minimum recall - the inverse trade."""
+    precision, recall, _ = precision_recall_curve(y_true, y_score)
+
+    results = {}
+    for target in targets:
+        feasible = precision[recall >= target]
+        results[f"r>={target:.2f}"] = round(float(feasible.max()), 6) if feasible.size else 0.0
+    return results
+
+
+def cost_analysis(
+    y_true: np.ndarray,
+    y_score: np.ndarray,
+    amounts: np.ndarray,
+    threshold: float,
+    review_cost: float = DEFAULT_REVIEW_COST,
+) -> dict:
+    """
+    Money saved versus doing nothing, in the units of ``amounts``.
+
+    Fraud is not uniformly expensive, so counting cases treats a $2 card test
+    and a $2,000 cash-out as the same event. This weights each by its amount:
+    a caught fraud saves its value, a missed one loses it, and a false alarm
+    costs one review.
+
+    ``net_savings`` can be negative - a model that alerts on everything catches
+    all fraud and still loses money. Reporting only recall would hide that.
+    """
+    flagged = y_score >= threshold
+    is_fraud = y_true == 1
+
+    prevented = float(amounts[flagged & is_fraud].sum())
+    missed = float(amounts[~flagged & is_fraud].sum())
+    reviews = int((flagged & ~is_fraud).sum())
+    exposure = float(amounts[is_fraud].sum())
+
+    net = prevented - reviews * review_cost
+
+    return {
+        "review_cost_per_alert": review_cost,
+        "total_fraud_exposure": round(exposure, 2),
+        "fraud_prevented": round(prevented, 2),
+        "fraud_missed": round(missed, 2),
+        "false_alarm_cost": round(reviews * review_cost, 2),
+        "net_savings": round(net, 2),
+        "savings_rate": round(net / exposure, 6) if exposure else 0.0,
+    }
+
+
+def choose_threshold(
+    y_true: np.ndarray,
+    y_score: np.ndarray,
+    amounts: np.ndarray,
+    review_cost: float = DEFAULT_REVIEW_COST,
+) -> float:
+    """
+    Pick the threshold maximising net savings.
+
+    Must be called on validation data, never on test: choosing an operating
+    point on the same rows used to report performance is how a tuned threshold
+    turns into an inflated result.
+    """
+    _, _, thresholds = precision_recall_curve(y_true, y_score)
+    if thresholds.size == 0:
+        return 0.5
+
+    # Scan a bounded sample - the curve yields one threshold per distinct
+    # score, which is hundreds of thousands of points on a full dataset.
+    candidates = np.quantile(thresholds, np.linspace(0, 1, num=min(200, thresholds.size)))
+
+    best_threshold, best_savings = 0.5, -np.inf
+    for threshold in candidates:
+        savings = cost_analysis(y_true, y_score, amounts, threshold, review_cost)["net_savings"]
+        if savings > best_savings:
+            best_threshold, best_savings = float(threshold), savings
+
+    return best_threshold
+
+
+def evaluate(
+    model_name: str,
+    y_true: np.ndarray,
+    y_score: np.ndarray,
+    amounts: np.ndarray,
+    threshold: float,
+    review_cost: float = DEFAULT_REVIEW_COST,
+) -> EvaluationReport:
+    """Full evaluation of one model's scores at a chosen threshold."""
+    y_true = np.asarray(y_true)
+    y_score = np.asarray(y_score)
+
+    return EvaluationReport(
+        model_name=model_name,
+        average_precision=float(average_precision_score(y_true, y_score)),
+        roc_auc=float(roc_auc_score(y_true, y_score)),
+        brier_score=float(np.mean((y_score - y_true) ** 2)),
+        positives=int(y_true.sum()),
+        negatives=int(len(y_true) - y_true.sum()),
+        at_threshold=metrics_at_threshold(y_true, y_score, threshold),
+        recall_at_precision=recall_at_precision(y_true, y_score, (0.5, 0.75, 0.9, 0.95)),
+        precision_at_recall=precision_at_recall(y_true, y_score, (0.5, 0.75, 0.9)),
+        cost=cost_analysis(y_true, y_score, amounts, threshold, review_cost),
+    )

--- a/src/training/pipeline.py
+++ b/src/training/pipeline.py
@@ -1,0 +1,335 @@
+"""
+Training pipeline for fraud detection models.
+
+Two methodology choices do most of the work here, and getting either wrong
+produces impressive numbers that do not survive deployment.
+
+**Temporal splitting.** Transactions are ordered in time and fraud patterns
+drift. A random split lets the model train on transactions that happened after
+the ones it is tested on, which is information it will never have in
+production. Splits here are strictly forward in time.
+
+**Fitting only on training data.** Scaling and resampling are fitted inside the
+training fold alone. Fitting a scaler on the full dataset leaks the test set's
+distribution; oversampling before splitting is worse still, because copies of
+the same fraud land on both sides of the split and the model is scored on rows
+it memorised. This is the single most common flaw in published fraud results.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import joblib
+import numpy as np
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.linear_model import LogisticRegression
+from sklearn.preprocessing import StandardScaler
+
+from src.training.dataset import (
+    FEATURE_COLUMNS,
+    LABEL_COLUMN,
+    TIME_COLUMN,
+    Dataset,
+    load_dataset,
+)
+from src.training.evaluation import (
+    DEFAULT_REVIEW_COST,
+    EvaluationReport,
+    choose_threshold,
+    evaluate,
+)
+
+logger = logging.getLogger(__name__)
+
+ARTIFACT_VERSION = "1.0.0"
+
+
+@dataclass(frozen=True)
+class Split:
+    """One forward-in-time slice of the data."""
+
+    name: str
+    features: np.ndarray
+    labels: np.ndarray
+    amounts: np.ndarray
+    time_start: float
+    time_end: float
+
+    def describe(self) -> dict:
+        return {
+            "name": self.name,
+            "rows": len(self.labels),
+            "fraud_rows": int(self.labels.sum()),
+            "fraud_rate": round(float(self.labels.mean()), 6),
+            "time_start": round(self.time_start, 1),
+            "time_end": round(self.time_end, 1),
+        }
+
+
+@dataclass
+class TrainingConfig:
+    """Knobs for a training run."""
+
+    train_fraction: float = 0.6
+    validation_fraction: float = 0.2
+    # Remainder is test.
+
+    review_cost: float = DEFAULT_REVIEW_COST
+    random_state: int = 42
+
+    # Weighting the rare class beats duplicating it: no synthetic rows, no risk
+    # of the same fraud appearing on both sides of a split, and nothing extra
+    # to install.
+    use_class_weights: bool = True
+
+    models: tuple[str, ...] = ("logistic_regression", "random_forest", "gradient_boosting")
+
+
+@dataclass
+class TrainingResult:
+    """Everything one run produced."""
+
+    data: dict
+    splits: list[dict]
+    config: dict
+    reports: dict[str, EvaluationReport]
+    best_model: str
+    threshold: float
+    baseline_average_precision: float
+    trained_at: str = field(default_factory=lambda: datetime.now(UTC).isoformat())
+
+    def to_dict(self) -> dict:
+        return {
+            "trained_at": self.trained_at,
+            "artifact_version": ARTIFACT_VERSION,
+            "data": self.data,
+            "splits": self.splits,
+            "config": self.config,
+            # A random model's average precision equals the fraud rate. Every
+            # score below is only meaningful as a multiple of this floor.
+            "baseline_average_precision": round(self.baseline_average_precision, 6),
+            "best_model": self.best_model,
+            "threshold": round(self.threshold, 6),
+            "models": {name: report.to_dict() for name, report in self.reports.items()},
+        }
+
+
+def temporal_split(dataset: Dataset, config: TrainingConfig) -> tuple[Split, Split, Split]:
+    """
+    Cut the data into train / validation / test, forward in time.
+
+    No shuffling anywhere. Every validation row happens after every training
+    row, and every test row after those.
+    """
+    frame = dataset.frame
+    n = len(frame)
+
+    train_end = int(n * config.train_fraction)
+    validation_end = train_end + int(n * config.validation_fraction)
+
+    bounds = {
+        "train": (0, train_end),
+        "validation": (train_end, validation_end),
+        "test": (validation_end, n),
+    }
+
+    splits = []
+    for name, (start, stop) in bounds.items():
+        window = frame.iloc[start:stop]
+        splits.append(
+            Split(
+                name=name,
+                features=window[list(FEATURE_COLUMNS)].to_numpy(dtype=np.float64),
+                labels=window[LABEL_COLUMN].to_numpy(dtype=np.int8),
+                amounts=window["Amount"].to_numpy(dtype=np.float64),
+                time_start=float(window[TIME_COLUMN].iloc[0]),
+                time_end=float(window[TIME_COLUMN].iloc[-1]),
+            )
+        )
+
+    train, validation, test = splits
+
+    # The guarantee this function exists to provide, asserted rather than
+    # assumed: a silently random split still trains and still reports numbers.
+    if not (train.time_end <= validation.time_start <= validation.time_end <= test.time_start):
+        raise RuntimeError("splits overlap in time; the split is not forward-in-time")
+
+    return train, validation, test
+
+
+def _build_models(config: TrainingConfig, scale_pos_weight: float) -> dict[str, Any]:
+    """
+    Instantiate the model zoo.
+
+    Every model is told the classes are imbalanced. Left at defaults, each one
+    converges on predicting the majority class, which is optimal for accuracy
+    and useless for fraud.
+    """
+    weight = "balanced" if config.use_class_weights else None
+    available: dict[str, Any] = {
+        "logistic_regression": LogisticRegression(
+            max_iter=2000,
+            class_weight=weight,
+            random_state=config.random_state,
+        ),
+        "random_forest": RandomForestClassifier(
+            n_estimators=200,
+            min_samples_leaf=5,
+            class_weight="balanced_subsample" if config.use_class_weights else None,
+            n_jobs=-1,
+            random_state=config.random_state,
+        ),
+    }
+
+    try:
+        from xgboost import XGBClassifier
+
+        available["gradient_boosting"] = XGBClassifier(
+            n_estimators=300,
+            max_depth=5,
+            learning_rate=0.1,
+            subsample=0.8,
+            colsample_bytree=0.8,
+            eval_metric="aucpr",
+            scale_pos_weight=scale_pos_weight if config.use_class_weights else 1.0,
+            random_state=config.random_state,
+            n_jobs=-1,
+        )
+    except ImportError:
+        # Optional extra. Its absence narrows the comparison; it does not
+        # invalidate the run, so it is logged rather than raised.
+        logger.warning("xgboost not installed; skipping gradient_boosting")
+
+    return {name: model for name, model in available.items() if name in config.models}
+
+
+def train(
+    dataset: Dataset | None = None,
+    config: TrainingConfig | None = None,
+    data_path: str | Path | None = None,
+) -> tuple[TrainingResult, dict[str, Any], StandardScaler]:
+    """
+    Train and evaluate the model zoo.
+
+    Returns the report, the fitted models, and the fitted scaler.
+    """
+    config = config or TrainingConfig()
+    dataset = dataset or load_dataset(data_path)
+
+    train_split, validation_split, test_split = temporal_split(dataset, config)
+
+    logger.info(
+        "Split %d rows: train=%d validation=%d test=%d",
+        len(dataset.frame),
+        len(train_split.labels),
+        len(validation_split.labels),
+        len(test_split.labels),
+    )
+
+    # Fitted on training rows only. Calling fit_transform on the full matrix
+    # would fold the test set's mean and variance into the training data.
+    scaler = StandardScaler().fit(train_split.features)
+
+    x_train = scaler.transform(train_split.features)
+    x_validation = scaler.transform(validation_split.features)
+    x_test = scaler.transform(test_split.features)
+
+    n_positive = max(int(train_split.labels.sum()), 1)
+    scale_pos_weight = (len(train_split.labels) - n_positive) / n_positive
+
+    models = _build_models(config, scale_pos_weight)
+    if not models:
+        raise RuntimeError("no models available to train")
+
+    reports: dict[str, EvaluationReport] = {}
+    fitted: dict[str, Any] = {}
+
+    for name, model in models.items():
+        logger.info("Training %s", name)
+        model.fit(x_train, train_split.labels)
+
+        # Threshold chosen on validation, then applied unchanged to test.
+        validation_scores = model.predict_proba(x_validation)[:, 1]
+        threshold = choose_threshold(
+            validation_split.labels,
+            validation_scores,
+            validation_split.amounts,
+            config.review_cost,
+        )
+
+        test_scores = model.predict_proba(x_test)[:, 1]
+        reports[name] = evaluate(
+            model_name=name,
+            y_true=test_split.labels,
+            y_score=test_scores,
+            amounts=test_split.amounts,
+            threshold=threshold,
+            review_cost=config.review_cost,
+        )
+        fitted[name] = model
+
+        logger.info(
+            "%s: AP=%.4f ROC-AUC=%.4f recall=%.3f precision=%.3f",
+            name,
+            reports[name].average_precision,
+            reports[name].roc_auc,
+            reports[name].at_threshold.recall,
+            reports[name].at_threshold.precision,
+        )
+
+    best_model = max(reports, key=lambda name: reports[name].average_precision)
+
+    result = TrainingResult(
+        data=dataset.describe(),
+        splits=[s.describe() for s in (train_split, validation_split, test_split)],
+        config={
+            "train_fraction": config.train_fraction,
+            "validation_fraction": config.validation_fraction,
+            "review_cost": config.review_cost,
+            "use_class_weights": config.use_class_weights,
+            "split_strategy": "temporal-forward",
+        },
+        reports=reports,
+        best_model=best_model,
+        threshold=reports[best_model].at_threshold.threshold,
+        baseline_average_precision=float(test_split.labels.mean()),
+    )
+
+    return result, fitted, scaler
+
+
+def save_artifacts(
+    result: TrainingResult,
+    models: dict[str, Any],
+    scaler: StandardScaler,
+    output_dir: str | Path,
+) -> Path:
+    """
+    Persist models, scaler, feature order and the metrics report.
+
+    Feature order is saved because the serving path reconstructs a row from a
+    feature dict; a different column order would silently score nonsense.
+
+    The report is written next to the models on purpose - an artefact whose
+    measured performance cannot be found is an artefact nobody can judge.
+    """
+    directory = Path(output_dir)
+    directory.mkdir(parents=True, exist_ok=True)
+
+    for name, model in models.items():
+        joblib.dump(model, directory / f"{name}.joblib")
+
+    joblib.dump(scaler, directory / "scaler.joblib")
+    joblib.dump(list(FEATURE_COLUMNS), directory / "feature_names.joblib")
+
+    report_path = directory / "metrics.json"
+    report_path.write_text(json.dumps(result.to_dict(), indent=2), encoding="utf-8")
+
+    logger.info("Wrote %d models and metrics.json to %s", len(models), directory)
+    return report_path

--- a/tests/integration/test_model_serving.py
+++ b/tests/integration/test_model_serving.py
@@ -1,0 +1,156 @@
+"""
+Integration tests for serving trained model artefacts.
+
+Covers the seam between training and serving, where mistakes are silent: a
+model fed unscaled features, or features in the wrong column order, returns a
+confident probability rather than an error. Nothing downstream can tell the
+difference.
+"""
+
+import numpy as np
+import pytest
+
+from app.services.fraud_detection_service import (
+    HEURISTIC_MODEL_NAME,
+    FraudDetectionService,
+    HeuristicMLModel,
+    JoblibEnsembleModel,
+)
+from src.training.dataset import FEATURE_COLUMNS, generate_calibrated
+from src.training.pipeline import TrainingConfig, save_artifacts, train
+
+
+@pytest.fixture(scope="module")
+def artefacts(tmp_path_factory):
+    """Train a small model once and persist it."""
+    directory = tmp_path_factory.mktemp("models")
+    dataset = generate_calibrated(rows=8_000, seed=11)
+    config = TrainingConfig(models=("logistic_regression",))
+
+    result, models, scaler = train(dataset=dataset, config=config)
+    save_artifacts(result, models, scaler, directory)
+
+    return directory
+
+
+class TestArtefactLoading:
+    def test_trained_artefacts_are_served_not_the_heuristic(self, artefacts):
+        service = FraudDetectionService._load_model_service(str(artefacts))
+
+        assert isinstance(service, JoblibEnsembleModel)
+
+    def test_scaler_is_not_loaded_as_a_model(self, artefacts):
+        """
+        scaler.joblib sits beside the models. Loading it into the ensemble
+        would call predict_proba on a StandardScaler.
+        """
+        service = FraudDetectionService._load_model_service(str(artefacts))
+
+        assert "scaler" not in service._models
+        assert "feature_names" not in service._models
+
+    def test_missing_directory_falls_back_to_the_heuristic(self, tmp_path):
+        service = FraudDetectionService._load_model_service(str(tmp_path / "absent"))
+
+        assert isinstance(service, HeuristicMLModel)
+
+    def test_models_without_a_scaler_are_refused(self, artefacts, tmp_path):
+        """
+        Serving unscaled rows to models fitted on scaled ones yields plausible,
+        wrong probabilities. Refusing is the only safe response.
+        """
+        import shutil
+
+        for name in ("logistic_regression.joblib", "feature_names.joblib"):
+            shutil.copy(artefacts / name, tmp_path / name)
+
+        service = FraudDetectionService._load_model_service(str(tmp_path))
+
+        assert isinstance(service, HeuristicMLModel)
+
+    def test_version_is_taken_from_the_training_report(self, artefacts):
+        """A score should be traceable to the run that produced its model."""
+        service = FraudDetectionService._load_model_service(str(artefacts))
+
+        assert service._version != "unknown"
+
+
+class TestScalingIsApplied:
+    def test_scaler_transform_is_used(self, artefacts):
+        service = FraudDetectionService._load_model_service(str(artefacts))
+        features = dict.fromkeys(FEATURE_COLUMNS, 2.0)
+
+        calls = []
+        real_transform = service._scaler.transform
+        service._scaler.transform = lambda row: calls.append(row) or real_transform(row)
+
+        service.predict(features)
+
+        assert calls, "predict() bypassed the scaler"
+
+    def test_scores_match_calling_the_model_directly(self, artefacts):
+        """
+        The serving path must reproduce what the model produces when handed a
+        correctly scaled, correctly ordered row.
+        """
+        service = FraudDetectionService._load_model_service(str(artefacts))
+        features = dict.fromkeys(FEATURE_COLUMNS, 1.5)
+
+        served = service.predict(features)["logistic_regression"].fraud_probability
+
+        row = np.array([[features[name] for name in FEATURE_COLUMNS]])
+        expected = service._models["logistic_regression"].predict_proba(
+            service._scaler.transform(row)
+        )[0][1]
+
+        assert served == pytest.approx(expected)
+
+    def test_feature_order_follows_the_saved_names(self, artefacts):
+        """
+        Rows are rebuilt from a dict. If order came from dict insertion rather
+        than the saved names, values would land on the wrong coefficients.
+        """
+        service = FraudDetectionService._load_model_service(str(artefacts))
+
+        forward = {name: float(i) for i, name in enumerate(FEATURE_COLUMNS)}
+        reversed_insertion = dict(reversed(list(forward.items())))
+
+        assert (
+            service.predict(forward)["logistic_regression"].fraud_probability
+            == service.predict(reversed_insertion)["logistic_regression"].fraud_probability
+        )
+
+
+class TestDiscrimination:
+    def test_extreme_features_score_higher_than_typical_ones(self, artefacts):
+        """
+        End-to-end sanity: a trained model must separate the two. If the scaler
+        were skipped, this ordering would not survive.
+        """
+        service = FraudDetectionService._load_model_service(str(artefacts))
+
+        typical = service.predict(dict.fromkeys(FEATURE_COLUMNS, 0.05))
+        extreme = service.predict(dict.fromkeys(FEATURE_COLUMNS, 3.5))
+
+        assert (
+            extreme["logistic_regression"].fraud_probability
+            > typical["logistic_regression"].fraud_probability
+        )
+
+    def test_missing_features_default_to_zero_without_raising(self, artefacts):
+        service = FraudDetectionService._load_model_service(str(artefacts))
+
+        prediction = service.predict({"V1": 1.0})["logistic_regression"]
+
+        assert 0.0 <= prediction.fraud_probability <= 1.0
+
+
+class TestHeuristicIsDistinguishable:
+    def test_heuristic_never_borrows_a_trained_model_name(self):
+        prediction = HeuristicMLModel().predict({"V1": 1.0})
+
+        assert set(prediction) == {HEURISTIC_MODEL_NAME}
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/unit/test_training.py
+++ b/tests/unit/test_training.py
@@ -1,0 +1,311 @@
+"""
+Tests for the training pipeline.
+
+These guard methodology, not accuracy. A leaking pipeline still trains, still
+prints metrics, and still looks better than a correct one - which is exactly
+why the guarantees have to be asserted rather than assumed.
+"""
+
+import json
+
+import numpy as np
+import pytest
+
+from src.training.dataset import (
+    FEATURE_COLUMNS,
+    LABEL_COLUMN,
+    TIME_COLUMN,
+    ULB_FRAUD_RATE,
+    DataSource,
+    generate_calibrated,
+    load_dataset,
+)
+from src.training.evaluation import (
+    choose_threshold,
+    cost_analysis,
+    evaluate,
+    metrics_at_threshold,
+    precision_at_recall,
+    recall_at_precision,
+)
+from src.training.pipeline import TrainingConfig, save_artifacts, temporal_split, train
+
+
+@pytest.fixture(scope="module")
+def dataset():
+    return generate_calibrated(rows=12_000, seed=7)
+
+
+class TestDatasetProvenance:
+    """Synthetic numbers must never be mistakable for measured ones."""
+
+    def test_generated_data_is_labelled_synthetic(self, dataset):
+        assert dataset.source is DataSource.SYNTHETIC_CALIBRATED
+        assert dataset.source.is_real is False
+        assert dataset.describe()["is_real_data"] is False
+
+    def test_missing_csv_falls_back_to_synthetic_not_an_error(self, tmp_path):
+        result = load_dataset(tmp_path / "nope.csv", rows=2_000)
+
+        assert result.source is DataSource.SYNTHETIC_CALIBRATED
+
+    def test_real_csv_is_labelled_real(self, tmp_path, dataset):
+        path = tmp_path / "creditcard.csv"
+        dataset.frame.to_csv(path, index=False)
+
+        assert load_dataset(path).source is DataSource.ULB_CREDITCARD
+
+
+class TestCalibration:
+    def test_fraud_rate_matches_the_published_figure(self, dataset):
+        assert dataset.fraud_rate == pytest.approx(ULB_FRAUD_RATE, abs=5e-4)
+
+    def test_rows_are_time_ordered(self, dataset):
+        assert dataset.frame[TIME_COLUMN].is_monotonic_increasing
+
+    def test_unsorted_input_is_rejected(self, dataset):
+        from src.training.dataset import Dataset
+
+        shuffled = dataset.frame.sample(frac=1.0, random_state=0)
+
+        with pytest.raises(ValueError, match="sorted by Time"):
+            Dataset(frame=shuffled, source=DataSource.SYNTHETIC_CALIBRATED)
+
+    def test_the_task_is_neither_trivial_nor_impossible(self):
+        """
+        A generator that makes fraud trivially separable produces a flattering
+        score that measures the generator. The first version of this one hit
+        ROC-AUC 0.9999; this pins the difficulty near what published models
+        reach on the real dataset.
+        """
+        from sklearn.ensemble import RandomForestClassifier
+        from sklearn.metrics import average_precision_score
+
+        data = generate_calibrated(rows=40_000, seed=3).frame
+        x = data[list(FEATURE_COLUMNS)].to_numpy()
+        y = data[LABEL_COLUMN].to_numpy()
+        cut = int(len(y) * 0.7)
+
+        model = RandomForestClassifier(
+            n_estimators=80,
+            min_samples_leaf=3,
+            class_weight="balanced_subsample",
+            n_jobs=-1,
+            random_state=0,
+        ).fit(x[:cut], y[:cut])
+
+        ap = average_precision_score(y[cut:], model.predict_proba(x[cut:])[:, 1])
+
+        assert 0.3 < ap < 0.95, f"generated task is miscalibrated (AP={ap:.3f})"
+
+
+class TestTemporalSplit:
+    """
+    Splits must run forward in time. A random split lets a model train on
+    transactions that happened after the ones it is scored on - information it
+    will never have in production.
+    """
+
+    def test_splits_do_not_overlap_in_time(self, dataset):
+        train_split, validation, test = temporal_split(dataset, TrainingConfig())
+
+        assert train_split.time_end <= validation.time_start
+        assert validation.time_end <= test.time_start
+
+    def test_every_row_lands_in_exactly_one_split(self, dataset):
+        train_split, validation, test = temporal_split(dataset, TrainingConfig())
+
+        total = len(train_split.labels) + len(validation.labels) + len(test.labels)
+
+        assert total == len(dataset.frame)
+
+    def test_split_sizes_follow_the_configured_fractions(self, dataset):
+        config = TrainingConfig(train_fraction=0.5, validation_fraction=0.25)
+        train_split, validation, _test = temporal_split(dataset, config)
+
+        n = len(dataset.frame)
+
+        assert len(train_split.labels) == pytest.approx(n * 0.5, rel=0.01)
+        assert len(validation.labels) == pytest.approx(n * 0.25, rel=0.01)
+
+    def test_fraud_appears_in_every_split(self, dataset):
+        """Otherwise the evaluation would have nothing to measure."""
+        for split in temporal_split(dataset, TrainingConfig()):
+            assert split.labels.sum() > 0, f"{split.name} contains no fraud"
+
+
+class TestNoLeakage:
+    """
+    The scaler must see training rows only. Fitting it on the full dataset
+    folds the test set's mean and variance into training - the single most
+    common flaw in published fraud results, and invisible in the output.
+    """
+
+    def test_scaler_is_fitted_on_training_rows_only(self, dataset):
+        config = TrainingConfig(models=("logistic_regression",))
+        train_split, _, _ = temporal_split(dataset, config)
+
+        _, _, scaler = train(dataset=dataset, config=config)
+
+        expected = train_split.features.mean(axis=0)
+
+        np.testing.assert_allclose(scaler.mean_, expected, rtol=1e-9)
+
+    def test_scaler_does_not_match_full_dataset_statistics(self, dataset):
+        """The inverse check: it must NOT have seen everything."""
+        config = TrainingConfig(models=("logistic_regression",))
+
+        _, _, scaler = train(dataset=dataset, config=config)
+
+        full = dataset.frame[list(FEATURE_COLUMNS)].to_numpy().mean(axis=0)
+
+        assert not np.allclose(scaler.mean_, full, rtol=1e-6)
+
+
+class TestEvaluationMetrics:
+    def test_perfect_scores_give_average_precision_one(self):
+        y = np.array([0, 0, 1, 1])
+        report = evaluate("perfect", y, np.array([0.1, 0.2, 0.9, 0.95]), np.ones(4), 0.5)
+
+        assert report.average_precision == pytest.approx(1.0)
+        assert report.at_threshold.recall == 1.0
+
+    def test_threshold_metrics_match_a_hand_computed_confusion_matrix(self):
+        y = np.array([0, 0, 1, 1])
+        scores = np.array([0.1, 0.8, 0.7, 0.2])
+
+        m = metrics_at_threshold(y, scores, 0.5)
+
+        assert (m.true_positives, m.false_positives) == (1, 1)
+        assert (m.true_negatives, m.false_negatives) == (1, 1)
+        assert m.precision == pytest.approx(0.5)
+        assert m.recall == pytest.approx(0.5)
+
+    def test_recall_at_precision_is_monotonically_non_increasing(self):
+        rng = np.random.default_rng(0)
+        y = rng.binomial(1, 0.05, 2_000)
+        scores = np.clip(y * 0.4 + rng.random(2_000) * 0.6, 0, 1)
+
+        result = recall_at_precision(y, scores, (0.3, 0.6, 0.9))
+        values = list(result.values())
+
+        assert values == sorted(values, reverse=True)
+
+    def test_precision_at_recall_returns_a_value_per_target(self):
+        rng = np.random.default_rng(1)
+        y = rng.binomial(1, 0.1, 500)
+        scores = rng.random(500)
+
+        assert set(precision_at_recall(y, scores, (0.5, 0.9))) == {"r>=0.50", "r>=0.90"}
+
+    def test_cost_weights_fraud_by_amount_not_by_count(self):
+        """
+        One $10,000 fraud missed must not cost the same as one $10 fraud
+        missed. Counting cases treats a card test and a cash-out alike.
+        """
+        y = np.array([1, 1])
+        scores = np.array([0.9, 0.1])  # catches the first, misses the second
+        amounts = np.array([10.0, 10_000.0])
+
+        cost = cost_analysis(y, scores, amounts, threshold=0.5)
+
+        assert cost["fraud_prevented"] == pytest.approx(10.0)
+        assert cost["fraud_missed"] == pytest.approx(10_000.0)
+
+    def test_net_savings_can_be_negative(self):
+        """
+        A model that alerts on everything catches all fraud and still loses
+        money. Reporting recall alone would hide that.
+        """
+        y = np.zeros(1_000, dtype=int)
+        scores = np.ones(1_000)
+
+        cost = cost_analysis(y, scores, np.ones(1_000), threshold=0.5, review_cost=3.0)
+
+        assert cost["net_savings"] < 0
+
+    def test_chosen_threshold_beats_the_extremes(self):
+        rng = np.random.default_rng(2)
+        y = rng.binomial(1, 0.02, 3_000)
+        scores = np.clip(y * 0.5 + rng.random(3_000) * 0.5, 0, 1)
+        amounts = rng.lognormal(4, 1, 3_000)
+
+        chosen = choose_threshold(y, scores, amounts)
+        best = cost_analysis(y, scores, amounts, chosen)["net_savings"]
+        alert_on_everything = cost_analysis(y, scores, amounts, 0.0)["net_savings"]
+
+        assert best >= alert_on_everything
+
+
+class TestTrainingRun:
+    def test_produces_a_report_naming_its_data_source(self, dataset):
+        config = TrainingConfig(models=("logistic_regression",))
+
+        result, models, _ = train(dataset=dataset, config=config)
+        report = result.to_dict()
+
+        assert report["data"]["source"] == DataSource.SYNTHETIC_CALIBRATED.value
+        assert report["data"]["is_real_data"] is False
+        assert report["config"]["split_strategy"] == "temporal-forward"
+        assert set(models) == {"logistic_regression"}
+
+    def test_reports_the_random_baseline_beside_the_score(self, dataset):
+        """
+        Average precision is meaningless without it: 0.8 is excellent against a
+        0.0017 baseline and unremarkable against 0.5.
+
+        The baseline is the *test split's* own positive rate, which is what a
+        random scorer would achieve on exactly those rows. It drifts from the
+        population rate on small samples, and using the population figure would
+        misstate the floor the score is measured against.
+        """
+        config = TrainingConfig(models=("logistic_regression",))
+        _, _, test_split = temporal_split(dataset, config)
+
+        result, _, _ = train(dataset=dataset, config=config)
+
+        assert result.baseline_average_precision == pytest.approx(float(test_split.labels.mean()))
+        assert (
+            result.reports["logistic_regression"].average_precision
+            > result.baseline_average_precision
+        )
+
+    def test_beats_the_random_baseline_by_a_wide_margin(self, dataset):
+        result, _, _ = train(
+            dataset=dataset, config=TrainingConfig(models=("logistic_regression",))
+        )
+        report = result.reports["logistic_regression"]
+
+        assert report.average_precision > 20 * result.baseline_average_precision
+
+    def test_saves_models_scaler_feature_order_and_metrics(self, dataset, tmp_path):
+        config = TrainingConfig(models=("logistic_regression",))
+        result, models, scaler = train(dataset=dataset, config=config)
+
+        save_artifacts(result, models, scaler, tmp_path)
+
+        assert (tmp_path / "logistic_regression.joblib").is_file()
+        assert (tmp_path / "scaler.joblib").is_file()
+        assert (tmp_path / "feature_names.joblib").is_file()
+
+        report = json.loads((tmp_path / "metrics.json").read_text(encoding="utf-8"))
+
+        assert report["data"]["source"] == DataSource.SYNTHETIC_CALIBRATED.value
+        assert report["best_model"] == "logistic_regression"
+
+    def test_saved_feature_order_matches_the_training_order(self, dataset, tmp_path):
+        """
+        Serving rebuilds a row from a feature dict using this order. A mismatch
+        would feed values into the wrong coefficients and score silently wrong.
+        """
+        import joblib
+
+        config = TrainingConfig(models=("logistic_regression",))
+        result, models, scaler = train(dataset=dataset, config=config)
+        save_artifacts(result, models, scaler, tmp_path)
+
+        assert joblib.load(tmp_path / "feature_names.joblib") == list(FEATURE_COLUMNS)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
Closes the gap the README documented as "not measured": there was no training code and no evaluation, so nothing in the repository could measure anything.

> **Note on the request that prompted this.** I was asked to search for live/real banking data. I didn't, and I'd push back on anyone who says they can: real cardholder transactions are PCI-DSS/GDPR-protected PII, there is no legitimate public feed of them, and a source offering one is selling stolen data. What I used instead is the standard public research dataset this repo's schema is already built for.

## The dataset

The `V1`–`V28` schema already in `TransactionRequest` **is** the [ULB Credit Card Fraud Detection dataset](https://www.kaggle.com/datasets/mlg-ulb/creditcardfraud) — 284,807 real transactions from European cardholders over two days in September 2013, 492 of them fraud (0.172%). `V1`–`V28` are PCA components published in place of the raw fields, which is how real transaction data can be released at all.

It isn't redistributable and isn't vendored here. Pass `--data creditcard.csv`. Without it, a generator calibrated to that dataset's **published** statistics stands in — same fraud rate, 48-hour span, ~$88 mean amount.

**Every report carries `source` and `is_real_data`.** Given how much of this repo's history was removing fabricated metrics, a generated result must never be readable as a measured one.

## Methodology, which is most of the value

Two choices decide whether the numbers survive deployment:

**Forward-in-time splits.** Fraud patterns drift, so a random split trains on transactions that happened *after* those being scored. `temporal_split` asserts the ordering rather than assuming it — a silently random split still trains and still prints results.

**Preprocessing fitted on the training fold only.** Fitting a scaler on the full dataset folds the test distribution into training; oversampling before splitting is worse, putting copies of the same fraud on both sides so the model is scored on rows it memorised. This is [the most common flaw in published fraud results](https://arxiv.org/html/2506.02703v1) and it is invisible in the output — so two tests assert it, and I confirmed both fail when the fit is widened:

```
leak introduced → FAILED TestNoLeakage::test_scaler_is_fitted_on_training_rows_only
                  FAILED TestNoLeakage::test_scaler_does_not_match_full_dataset_statistics
```

## Metrics chosen for a 0.172% positive rate

**Accuracy is not reported.** Predicting "legitimate" for everything scores 99.83% and catches nothing — the metric rewards the exact failure being guarded against.

Average precision is the headline, always printed beside the random baseline (the fraud rate), without which no score can be read. ROC-AUC appears only for comparability, because under this imbalance it flatters — [published results show ROC-AUC 0.957 against PR-AUC 0.708](https://machinelearningmastery.com/roc-auc-vs-precision-recall-for-imbalanced-data/).

Also emitted: `recall_at_precision`, `precision_at_recall`, and an amount-weighted cost model. That last one matters because counting cases treats a $2 card test and a $2,000 cash-out alike — and because `net_savings` can go negative, which recall alone would hide.

## Two serving bugs this exposed

Both would have shipped silently:

- `scaler.joblib` sits beside the models in `MODEL_PATH`, and the loader globbed `*.joblib` — it would have called `predict_proba` on a `StandardScaler`.
- **The serving path never applied the scaler at all.** Models fitted on standardised features would have scored raw input, returning confident wrong probabilities rather than an error. Nothing downstream could have detected it. Models arriving without a scaler are now refused in favour of the heuristic.

`scikit-learn` moves to `requirements.txt` — the artefacts are pickled sklearn objects, so deserialising one needs it at runtime, not just for training.

## A worked run

284,807 rows, **calibrated synthetic**, forward-in-time split, threshold chosen on validation and applied unchanged to test:

| Model | AP | ROC-AUC | Precision | Recall | Net savings |
|---|---|---|---|---|---|
| logistic_regression | **0.796** | 0.889 | 0.309 | 0.808 | $6,733 |
| gradient_boosting | 0.796 | 0.894 | 0.286 | 0.798 | $6,554 |
| random_forest | 0.780 | 0.887 | 0.506 | 0.788 | $6,768 |

Random baseline AP **0.00174** — a ~458× lift. Note the shape: ROC-AUC 0.89 reads as unremarkable while PR-AUC shows real skill, which is the whole argument for the headline choice.

**These describe a generated problem.** They show the pipeline is correct, not that the model is accurate. I calibrated the generator's difficulty by sweeping its parameters against a fixed model — the first version shifted all 28 features and hit ROC-AUC 0.9999, a number that measured only the generator's generosity. It now sits near AP 0.75, the range published models reach on the real data, and a test pins it there.

## Verification

Fresh venv from `requirements.txt` + `requirements-dev.txt`, bare `pytest` as CI invokes it:

```
178 passed                      (was 142)
pip-audit --strict              No known vulnerabilities found
ruff check / format             clean
```

End-to-end against the API with `MODEL_PATH` populated:

```
/api/v1/health  → {"active_model": "joblib-ensemble", "trained": true, "count": 3}
benign features → fraud_probability 0.0016
extreme features→ fraud_probability 0.7032
```

That 0.70 spread only appears if the scaler is applied — it's the end-to-end check on the bug above.

## Follows #25

Branched off `fix/review-findings`. If #25 merges first this rebases cleanly; the changes don't overlap.
